### PR TITLE
fixup! feat(backend): Source ObjStore Creds from Env in Tekton Template

### DIFF
--- a/backend/src/apiserver/common/config.go
+++ b/backend/src/apiserver/common/config.go
@@ -48,6 +48,9 @@ const (
 	TerminateStatus                         string = "TERMINATE_STATUS"
 	MoveResultsImage                        string = "MOVERESULTS_IMAGE"
 	Path4InternalResults                    string = "PATH_FOR_INTERNAL_RESULTS"
+	ObjectStoreCredentialsSecret            string = "OBJECTSTORECONFIG_CREDENTIALSSECRET"
+	ObjectStoreCredentialsAccessKeyKey      string = "OBJECTSTORECONFIG_CREDENTIALSACCESSKEYKEY"
+	ObjectStoreCredentialsSecretKeyKey      string = "OBJECTSTORECONFIG_CREDENTIALSSECRETKEYKEY"
 	ObjectStoreAccessKey                    string = "OBJECTSTORECONFIG_ACCESSKEY"
 	ObjectStoreSecretKey                    string = "OBJECTSTORECONFIG_SECRETACCESSKEY"
 )
@@ -152,6 +155,18 @@ func GetObjectStoreAccessKey() string {
 
 func GetObjectStoreSecretKey() string {
 	return GetStringConfig(ObjectStoreSecretKey)
+}
+
+func GetObjectStoreCredentialsSecretName() string {
+	return GetStringConfigWithDefault(ObjectStoreCredentialsSecret, DefaultObjectStoreCredentialsSecret)
+}
+
+func GetObjectStoreCredentialsAccessKeyKey() string {
+	return GetStringConfigWithDefault(ObjectStoreCredentialsAccessKeyKey, DefaultObjectStoreCredentialsAccessKeyKey)
+}
+
+func GetObjectStoreCredentialsSecretKeyKey() string {
+	return GetStringConfigWithDefault(ObjectStoreCredentialsSecretKeyKey, DefaultObjectStoreCredentialsSecretKeyKey)
 }
 
 func GetMoveResultsImage() string {

--- a/backend/src/apiserver/common/const.go
+++ b/backend/src/apiserver/common/const.go
@@ -77,6 +77,12 @@ const (
 )
 
 const (
+	DefaultObjectStoreCredentialsSecret       string = "mlpipeline-minio-artifact"
+	DefaultObjectStoreCredentialsAccessKeyKey string = "accesskey"
+	DefaultObjectStoreCredentialsSecretKeyKey string = "secretkey"
+)
+
+const (
 	ArtifactItemsAnnotation          string = "tekton.dev/artifact_items"
 	ArtifactBucketAnnotation         string = "tekton.dev/artifact_bucket"
 	ArtifactEndpointAnnotation       string = "tekton.dev/artifact_endpoint"

--- a/backend/src/apiserver/template/tekton_template.go
+++ b/backend/src/apiserver/template/tekton_template.go
@@ -272,8 +272,9 @@ func (t *Tekton) injectArchivalStep(workflow util.Workflow, artifactItemsJSON ma
 		artifacts, hasArtifacts := artifactItemsJSON[task.Name]
 		archiveLogs := common.IsArchiveLogs()
 		trackArtifacts := common.IsTrackArtifacts()
-		objectStoreAccessKey := common.GetObjectStoreAccessKey()
-		objectStoreSecretKey := common.GetObjectStoreSecretKey()
+		objectStoreCredentialsSecretName := common.GetObjectStoreCredentialsSecretName()
+		objectStoreCredentialsSecretAccessKeyKey := common.GetObjectStoreCredentialsAccessKeyKey()
+		objectStoreCredentialsSecretSecretKeyKey := common.GetObjectStoreCredentialsSecretKeyKey()
 		stripEOF := common.IsStripEOF()
 		injectDefaultScript := common.IsInjectDefaultScript()
 		copyStepTemplate := common.GetCopyStepTemplate()
@@ -356,8 +357,8 @@ func (t *Tekton) injectArchivalStep(workflow util.Workflow, artifactItemsJSON ma
 					t.getObjectFieldSelector("PIPELINERUN", "metadata.labels['tekton.dev/pipelineRun']"),
 					t.getObjectFieldSelector("PODNAME", "metadata.name"),
 					t.getObjectFieldSelector("NAMESPACE", "metadata.namespace"),
-					t.getEnvVar("AWS_ACCESS_KEY_ID", objectStoreAccessKey),
-					t.getEnvVar("AWS_SECRET_ACCESS_KEY", objectStoreSecretKey),
+					t.getSecretKeySelector("AWS_ACCESS_KEY_ID", objectStoreCredentialsSecretName, objectStoreCredentialsSecretAccessKeyKey),
+					t.getSecretKeySelector("AWS_SECRET_ACCESS_KEY", objectStoreCredentialsSecretName, objectStoreCredentialsSecretSecretKeyKey),
 					t.getEnvVar("ARCHIVE_LOGS", strconv.FormatBool(archiveLogs)),
 					t.getEnvVar("TRACK_ARTIFACTS", strconv.FormatBool(trackArtifacts)),
 					t.getEnvVar("STRIP_EOF", strconv.FormatBool(stripEOF)),


### PR DESCRIPTION
Opening for peer review before updating upstream PR

Things addressed by this fixup:
- Maintain ability to specify an ObjectStore secret named something other than `mlpipeline-minio-artifact`
- revert back to using t.GetSecretKeySelector(). t.getEnv would expose the objstore secrets as plaintext in a tekton container spec
- introduce env vars for the ObjStore Secret Name, AccessKey key, and SecretKey key.
- allows infra admins to use a custom objstore Secret and keys across namespaces, with the restriction that they must be homogeneous across namespaces (ie, if OBJECTSTORECONFIG_CREDENTIALSECRETNAME is set to `foosecret`, *all* namespaces must name their Secret as `foosecret` and not `mlpipeline-minio-artifact`